### PR TITLE
logic to skip checks already tracked, readme & logging tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ For every monitor that has reported data, this plugin currently will calculate a
 * Component/Overall/Duration[ms]
 
 ## Configure for a Single Account
-There is a config file default.json which defines the required keys. You have 2 options for how to configure the keys:
-* Config File: Copy default.json and create your own config file
+There is a config file `default.json` which defines the required keys. You have 2 options for how to configure the keys:
+* Config File: Copy `default.json` and create your own config file
 * Environment Variables: Set environment variables
 
 ### Single Account: Config file
-Copy default.json and make your own file like ken-config.json. At runtime you must define an environment variable ```NODE_ENV``` and set to the name of your file (do not include the extension).
+Copy `default.json` and to your own file like `ken-config.json`. At runtime, you must define an environment variable ```NODE_ENV``` and set to the name of your file **(NOTE: do not include the extension)**.
+
+Example: `export NODE_ENV=ken-config.json`
 
 ### Single Account: Environment Variables
 If you want to query metrics from a single account and post to the same account, you can just set these 3 environment variables:
-* NEWRELIC_LICENSE_KEY maps to licenseKey (for plugin to publish metrics)
-* NEWRELIC_ACCOUNT_ID maps to accountId
-* NEWRELIC_INSIGHTS_QUERY_KEY maps to insightsQueryKey (for plugin to query metrics)
-* NEWRELIC_INSIGHTS_INSERT_KEY maps to insightsInsertKey (for plugin to publish events)
+* `NEWRELIC_LICENSE_KEY` maps to licenseKey (for plugin to publish metrics)
+* `NEWRELIC_ACCOUNT_ID` maps to accountId
+* `NEWRELIC_INSIGHTS_QUERY_KEY` maps to insightsQueryKey (for plugin to query metrics)
+* `NEWRELIC_INSIGHTS_INSERT_KEY` maps to insightsInsertKey (for plugin to publish events)
 
 ### Running the Plugin Directly
 You can run the plugin directly like so:
@@ -55,7 +57,7 @@ Tue, 20 Sep 2016 13:35:29 GMT - info: * Running as a single config.
 ## Running the Plugin with Forever
 Or you can use forever to launch the plugin (and re-launch if it crashes):
 ```
-kahrens:nr-synthetics-plugin kahrens$ ./node_modules/forever/bin/forever start index.js 
+kahrens:nr-synthetics-plugin kahrens$ ./node_modules/forever/bin/forever start index.js
 warn:    --minUptime not set. Defaulting to: 1000ms
 warn:    --spinSleepTime not set. Your script will exit if it does not stay up for at least 1000ms
 info:    Forever processing file: index.js
@@ -66,7 +68,7 @@ This is how you get a list of all your forever processes:
 kahrens:nr-synthetics-plugin kahrens$ ./node_modules/forever/bin/forever list
 info:    Forever processes running
 data:        uid  command             script   forever pid   id logfile                          uptime      
-data:    [0] UKn_ /usr/local/bin/node index.js 70782   70783    /Users/kahrens/.forever/UKn_.log 0:0:0:8.935 
+data:    [0] UKn_ /usr/local/bin/node index.js 70782   70783    /Users/kahrens/.forever/UKn_.log 0:0:0:8.935
 ```
 
 And this is how you get the log:
@@ -80,10 +82,10 @@ data:    index.js:71019 - Mon, 22 Aug 2016 12:46:00 GMT - info: getMonitorList f
 
 This is how you stop your plugin, then run ```list``` to see it's no longer running.
 ```
-kahrens:nr-synthetics-plugin kahrens$ ./node_modules/forever/bin/forever stop index.js 
+kahrens:nr-synthetics-plugin kahrens$ ./node_modules/forever/bin/forever stop index.js
 info:    Forever stopped process:
     uid  command             script   forever pid   id logfile                          uptime      
-[0] UKn_ /usr/local/bin/node index.js 70782   70783    /Users/kahrens/.forever/UKn_.log 0:0:8:0.212 
+[0] UKn_ /usr/local/bin/node index.js 70782   70783    /Users/kahrens/.forever/UKn_.log 0:0:8:0.212
 ```
 
 ### Running the Tests

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
   "guid": "com.adg.synthetics.monitor.Synthetics",
   "duration": 30,
   "licenseKey": "",
+  "logLevel": "info",
   "configArr": [
     "newrelic"
   ],

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ var getLocationStatus = function(monitorName, configId) {
   var nrql = locationStatusNRQL.replace('{monitorName}', monitorName);
   insights.query(nrql, configId, function(error, response, body) {
     if (!error && response.statusCode == 200) {
-      calculateMetrics(monitorName, body.facets, configId);
+      calculateMetrics(monitorName.replace('\\\'', '_'), body.facets, configId);
     } else {
       if (error) {
         logger.error('Error on Insights location status call');

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var logger = new (winston.Logger)({
 })
 
 // Used to keep track of synthetic checks that have already been reported
-// Structure: {monitorName: {locationName: locationId}}
+// Structure: {monitorName: {locationName: checkId}}
 var reportedChecks = {};
 
 // This will report the data from the Metric Array to Insights


### PR DESCRIPTION
Beautiful job with this man!

I’ve added some logic that makes sure a check that has already been considered in the generated metrics/events isn’t re-considered in subsequent iterations through the script.

It may be contradictory to some rationale you had for tracking things more than once, let me know if that’s the case.

Also, I made logging an optional config.json setting, and made a couple of minor tweaks to the readme.